### PR TITLE
Fix using correct canvas for drawing and input empty list

### DIFF
--- a/adjustText/__init__.py
+++ b/adjustText/__init__.py
@@ -71,7 +71,7 @@ def get_orig_coords(transform, t_x, t_y):
 
 def get_bboxes(objs, r=None, expand=(1, 1), ax=None, transform=None):
     """
-    
+
 
     Parameters
     ----------
@@ -561,8 +561,10 @@ def adjust_text(
     int
         Number of iteration
     """
-    plt.draw()
+    if not texts:
+        return 0
     ax = ax or plt.gca()
+    ax.figure.draw_without_rendering()
     r = get_renderer(ax.get_figure())
     transform = texts[0].get_transform()
     if (x is not None) & (y is not None):


### PR DESCRIPTION
Fixes #140 
Fixes #137 (I also had this issue)

The problem was that the way I was using it, from inside a library, for some reason the draw didn't happen with plt.draw(). Now, it should always work when passing `ax` (and seems to work for me even without it).

Modifying my own code to deal with #137 is simple, but considering that more people seem to be affected, I added a minor fix for that as well.

(Seems like my editor modified another line as well, hope that is OK...)