### PR TITLE
fix for numpy2.0

### DIFF
--- a/adjustText/__init__.py
+++ b/adjustText/__init__.py
@@ -573,7 +573,7 @@ def adjust_text(
     if isinstance(max_move, int):
         max_move = (max_move, max_move)
     elif max_move is None:
-        max_move = (np.Inf, np.Inf)
+        max_move = (np.inf, np.inf)
 
     if isinstance(force_explode, float):
         force_explode = (force_explode, force_explode)


### PR DESCRIPTION
numpy 2.0 deprecated `np.Inf` and needs `np.inf` now